### PR TITLE
chore(glide): update go-dev to 0.11.1 and update deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ else
 	GOOS=linux
 endif
 
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.9.1
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.11.1
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_PREFIX := docker run --rm -e GO15VENDOREXPERIMENT=1 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f9d81af83f2ae423545f0e20b78b6de738e0a4d5036e1ffc7bff38831f36f602
-updated: 2016-03-29T14:19:15.194477893-07:00
+hash: e6a7cc4f1ee8dda11e1efb830973ba5fb962638d0e4d1a430ecb3ee06a41e1f7
+updated: 2016-04-23T16:18:33.303711258Z
 imports:
 - name: github.com/arschles/assert
   version: d21ecd4884be33397d1298c3738b2b4937c7f499

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/arschles/object-storage-cli
+package: github.com/deis/object-storage-cli
 import:
 - package: github.com/codegangsta/cli
 - package: github.com/docker/distribution


### PR DESCRIPTION
This fixes a `glide` warning from `make bootstrap`:

```
[WARN] Lock file may be out of date. Hash check of YAML failed. You may need to run 'update'
```
